### PR TITLE
improve tags scape'r'n

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ rough example how this script was used for vol. 8:
 ```sh
 ruby scrape_indesign.rb -i /Users/edwardsharp/Desktop/index8/index8.html -d /Users/edwardsharp/Desktop/index8/out -v 2018 -p
 
-ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/terms.html --out /Users/edwardsharp/Desktop/index8/out --volume 2018 --terms
+ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/terms.html --out /Users/edwardsharp/Desktop/index8/out --volume 2018 --terms --dryrun
 
-ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/out/projects/2018/pages.json --out /Users/edwardsharp/Desktop/index8/out/projects/2018/ --writeterms
+ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/terms.html --out /Users/edwardsharp/src/github/emergencyindex/projects-2018 --terms
 
 ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/out/projects/2018/terms.json --termsindex
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,7 @@ ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/terms.html --
 
 ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/terms.html --out /Users/edwardsharp/src/github/emergencyindex/projects-2018 --terms
 
-ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/out/projects/2018/terms.json --termsindex
-
-ruby scrape_indesign.rb --tidy  /Users/edwardsharp/Desktop/index8/out/projects/2018/
+ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/terms.html --volume 2018 --termsindex
 ```
 use detox program (`brew install detox` or whatever) rename image files:  (-n for dry-run. detox removes bad filename charz)
 ```sh
@@ -130,4 +128,6 @@ use imagemagick (`brew install imagemagick` or whatever) to convert png -> jpgz:
 mogrify -format jpg *.png
 
 ruby scrape_indesign.rb --validateimages /Users/edwardsharp/Desktop/index8/out/projects/2018 --validateimagesdir /Users/edwardsharp/src/github/emergencyindex/projects-2018
+
+ruby scrape_indesign.rb --tidy  /Users/edwardsharp/Desktop/index8/out/projects/2018/
 ```

--- a/utilz/scrape_indesign.rb
+++ b/utilz/scrape_indesign.rb
@@ -351,6 +351,8 @@ module ScrapeIndesign
 
     page = Nokogiri::HTML(open(@options[:in_file]))
 
+    # note: this volume may or not have tags before "A"
+    
     md_out = %{---
 layout: page
 name: Terms
@@ -409,44 +411,6 @@ toc: #{@options[:vol]} Terms
     
     p "wrote to ./terms.md"
     File.open('terms.md',"w"){|f| f.write(md_out)}
-
-    #  p "reading #{@options[:in_file]}..."
-    #  # **Asia** _see also_ <span class="see-also">China</span> <span class="see-also">Japan</span>
-    #  j = JSON.parse( File.read(@options[:in_file]) )
-    #  len = j.length
-    #  idx = 0
-    #  md_out = ''
-    #  j.each do |item|
-    #    status_update(len:len, idx:idx)
-
-    #    if item[0].length === 1
-    #      # this must be a letter section heading
-    #      md_out += "{: ##{item[0]} .index .sticky-nav }\n"
-    #      md_out += "## #{item[0]}\n\n"
-    #    elsif item[1].length === 0
-    #       if item[0] =~ /see also/
-    #         splt = item[0].split('see also')
-    #         md_out += "**#{splt[0].strip}** _see also_ "
-    #         md_out += splt[1].split(',').map{ |t| "<span class=\"see-also\">#{t.strip}</span>"}.join(' ')
-    #         md_out += "\n\n"
-    #       elsif item[0] =~ /see/
-    #         splt = item[0].split('see')
-    #         md_out += "**#{splt[0].strip}** _see_ "
-    #         md_out += splt[1].split(',').map{ |t| "<span class=\"see-also\">#{t.strip}</span>"}.join(' ')
-    #         md_out += "\n\n"
-    #       else 
-    #         p "expected empty array to be see also ref, got: #{item[0]}"
-    #       end
-    #    else
-    #      md_out += "**#{item[0]}** "
-    #      md_out += item[1].map{ |pp| "[#{pp}]"}.join(', ')
-    #      md_out += "\n\n"
-    #    end
-       
-    #  end
-
-    #  p "wrote to ./terms.md"
-    #  File.open('terms.md',"w"){|f| f.write(md_out)}
 
   end
 
@@ -547,27 +511,6 @@ toc: #{@options[:vol]} Terms
 private
   def self.status_update(len:nil, idx:nil)
     print "\b" * 16, "Progress: #{(idx.to_f / len * 100).to_i}% ", @pinwheel.rotate!.first
-  end
-
-  def fix_2012_termz
-    f = "/Users/edward/src/tower/github/alveol.us/utilz/projects/2012/pages_edited.json"
-    j = JSON.parse( File.read(f) )
-
-    j.each do |i|
-      terms = i[1]
-      terms.each do |t|
-        m = t.match(/(.*)\(([a-z, ]*)\)/)
-        if m and m[2]
-          j[i[0]] -= [t]
-          j[i[0]] << m[2].split(',').collect{|s| "#{m[1].strip} #{s.strip}" }
-          j[i[0]].flatten!
-          j[i[0]].sort!
-        end
-      end
-    end
-
-    File.open("/Users/edward/src/tower/github/alveol.us/utilz/projects/2012/pages_edited_fixed_subtermz.json","w"){|f| f.write(j.to_json)}
-
   end
 
   def self.read_md file: ''

--- a/utilz/scrape_indesign.rb
+++ b/utilz/scrape_indesign.rb
@@ -27,12 +27,11 @@ module ScrapeIndesign
       opts.on('-v', '--volume VOLUME', 'Volume Name') { |v| @options[:vol] = v }
       opts.on('-o', '--pageoffset OFFSET', 'Page of first project') { |v| @options[:pageoffset] = v }
       opts.on("-p", "--projects", "Scrape Projects") { |v| @options[:projects] = v }
-      opts.on("-t", "--terms", "Scrape Terms") { |v| @options[:terms] = v }
-      opts.on("-u", "--termstxt", "Scrape Terms Text") { |v| @options[:terms_txt] = v }
-      opts.on("-T", "--writeterms", "Write Terms to MD") { |v| @options[:writeterms] = v }
+      opts.on("-t", "--terms", "Scrape Terms (use --dryrun first)") { |v| @options[:terms] = v }
       opts.on("-I", "--termsindex", "Build Terms Index MD") { |v| @options[:termsindex] = v }
       opts.on("-x", "--tidy DIRECTORY", "Tidy project YAML") { |v| @options[:tidy] = v }
       opts.on("-X", "--drytidy", "DRY RUN Tidy project YAML (no files modified)") { |v| @options[:drytidy] = v }
+      opts.on("-Z", "--dryrun", "DRY RUN (no files modified)") { |v| @options[:dryrun] = v }
       opts.on("-V", "--validateimages DIRECTORY", "Validate project image files. Specify project dir with .md files.") { |v| @options[:validate_images] = v }
       opts.on("-I", "--validateimagesdir DIRECTORY", "Validate project images. Specify directory with project images.") { |v| @options[:validate_images_dir] = v }
     end.parse!
@@ -48,10 +47,6 @@ module ScrapeIndesign
       scrape_projects_html
     elsif @options[:terms]
       scrape_terms_html
-    elsif @options[:terms_txt]
-      scrape_terms_txt
-    elsif @options[:writeterms]
-      write_terms_to_md
     elsif @options[:termsindex]
       build_terms_index
     elsif @options[:tidy]
@@ -259,148 +254,96 @@ module ScrapeIndesign
   end #scrape_projects_html
 
   def self.scrape_terms_html
-    # ex: ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/terms.html --out /Users/edwardsharp/Desktop/index8/out --volume 2018 --terms
+    # ex: ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/terms.html --out /Users/edwardsharp/Desktop/index8/out --volume 2018 --terms --dryrun
+    # ex: ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/terms.html --out /Users/edwardsharp/src/github/emergencyindex/projects-2018 --terms
     p "reading #{@options[:in_file]}..."
-    Dir.mkdir("#{@options[:out_dir]}/projects") unless Dir.exist?("#{@options[:out_dir]}/projects")
-    Dir.mkdir("#{@options[:out_dir]}/projects/#{@options[:vol]}") unless Dir.exist?("#{@options[:out_dir]}/projects/#{@options[:vol]}")
 
     page = Nokogiri::HTML(open(@options[:in_file]))
 
     terms = {}
+    
     page.css('p').each do |_p|
 
-      _terms = _p.text.split(';')
+      _span = _p.css('span')
+      
+      # skip if there's zero on one <span>
+      next if _span.length == 0 or _span.length == 1
+     
+      base = _span[0].text.strip
 
-      _baseTerm = _terms[0].match(/^[^\d]*/)[0].strip
-      _pages = _terms[0].gsub(/[^0-9,\ ]/, '').split(/,| /).reject(&:nil?)
+      _span.each_with_index do |_s, i|
+        next if i === 0
+        # yank common delinatorz used in page lists
+        no_delinatorz = _s.text.gsub(',','').gsub(' ','').gsub(';','')
+        # try to determine if this is all numbers and thus a list of pages.
+        # if there are more than 0 numbers and nothing else, it must be a list of pages. neat.
+        isNumeric = no_delinatorz.scan(/\d/).length > 0 and no_delinatorz.scan(/\D/).empty?
+        if isNumeric
+          # sometimes there's an empty span, so check for that and if so, use the span before that.
+          term = _span[i-1].text.strip.empty? ? _span[i-2].text.strip : _span[i-1].text.strip
+          term_pages = _s.text.gsub(';','').split(',').map{ |s| page_to_pages s}
 
-      if _baseTerm.include?('also ')
-        _also = _baseTerm.match(/also [^\d]*/)[0].gsub('also','').strip
-        # p "ALSO!! #{_also}"
-        terms[_also] ||= []
-        terms[_also] << _pages
-        terms[_also].flatten!
+          if terms[term]
+            terms[term] = terms[term].concat term_pages
+          else
+            terms[term] = term_pages
+          end
+
+          if base != term
+            p "adding base term: #{base}"
+            if terms[base]
+              terms[base] = terms[base].concat term_pages
+            else
+              terms[base] = term_pages
+            end
+          end
+
+          # p "zomg #{term} already here?????" if terms[term]
+          # terms[term] = term_pages
+        end
       end
 
-      _baseTerm.gsub!(/also (.*)/,'')
-      _baseTerm.gsub!(')','') if _baseTerm.include?(')') and !_baseTerm.include?('(')
-      _baseTerm.gsub!('(','') if _baseTerm.include?('(') and !_baseTerm.include?(')')
-      _baseTerm.strip!
+    end
 
-      terms[_baseTerm] ||= []
-      terms[_baseTerm] << _pages
-      terms[_baseTerm].flatten!
+    pages_data = {}
 
-
-      _terms[1..-1].each do |_t|
-        _subTerm = _t.match(/^[^\d]*/)[0]
-        _pages = _t.gsub(/[^0-9, ]/, '').split(/,| /).reject(&:nil?)
-        if _t.include?('also ')
-          _also = _t.match(/also [^\d]*/)[0].gsub('also','').strip
-          _also.gsub!(')','') if _also.include?(')') and !_also.include?('(')
-          # p "SUB ALSO: #{_also}"
-          terms[_also] ||= []
-          terms[_also] <<  _pages
-          terms[_also].flatten!
+    terms.each do |term, pages|
+      pages.each do |page|
+        if pages_data[page].nil? 
+          pages_data[page] = [term]
+        else
+          pages_data[page] << term
         end
-        terms[_baseTerm] ||= []
-        terms[_baseTerm] << _pages
-        terms[_baseTerm].flatten!
-        _subKey = "#{_baseTerm} #{_subTerm.gsub(/\(also (.*)\)/,'').strip}"
-        terms[_subKey] ||= []
-        terms[_subKey] << _pages
-        terms[_subKey].flatten!
       end
     end
 
-    p "writing #{terms.length} items to terms.json"
-    outfile = "#{@options[:out_dir]}/projects/#{@options[:vol]}/terms.json"
-    File.open(outfile,"w"){|f| f.write(terms.to_json)}
-
-
-    pages_hash = {}
-    terms.each do |term, pages|
-
-      pages.each do |page|
-        if page.to_i.even?
-          _next = (page.to_i + 1).to_s
-          _pages = "#{page.rjust(3, '0')}-#{_next.rjust(3, '0')}"
-        else
-          _prev = (page.to_i - 1).to_s
-          _pages = "#{_prev.rjust(3, '0')}-#{page.rjust(3, '0')}"
+    if @options[:dryrun]
+      p "...writing terms.json"
+      Dir.mkdir("#{@options[:out_dir]}/projects") unless Dir.exist?("#{@options[:out_dir]}/projects")
+      Dir.mkdir("#{@options[:out_dir]}/projects/#{@options[:vol]}") unless Dir.exist?("#{@options[:out_dir]}/projects/#{@options[:vol]}")
+      outdir = "#{@options[:out_dir]}/projects/#{@options[:vol]}"
+      File.open("#{outdir}/terms.json","w"){|f| f.write(JSON.pretty_generate(terms))}
+      p "...writing pages.json"
+      File.open("#{outdir}/pages.json","w"){|f| f.write(JSON.pretty_generate(pages_data))}
+    else
+      p "...writing project .md files (#{outdir})"
+      outdir = @options[:out_dir] = "#{@options[:out_dir]}/" unless @options[:out_dir][-1] == '/'
+      pages_data.each do |pages, terms|
+        project_file = "#{outdir}#{pages}.md"
+        unless File.exist?(project_file)
+          p "WARN: #{project_file} doesnot exist!"
+          p "terms: #{terms}"
+          next
         end
-
-        pages_hash[_pages] ||= []
-        pages_hash[_pages] << term unless pages_hash[_pages].include?(term) or term.nil?
+        project = read_md(file:project_file)
+        project[:yml]["tags"] = terms.sort_by(&:downcase).uniq
+        File.open(project_file,"w"){|f| f.write("#{project[:yml].to_yaml}---#{project[:description]}")}
       end
-
     end
 
     p "Done!"
-    outfile = "#{@options[:out_dir]}/projects/#{@options[:vol]}/pages.json"
-    File.open(outfile,"w"){|f| f.write(pages_hash.to_json)}
-    p "wrote #{pages_hash.length} items to #{outfile}"
 
   end #scrape_terms_html
-
-  def self.scrape_terms_txt
-    # read txt files like:
-    # TERM [...pages]
-    # example:  body 007, 023, 033, 119
-    p "reading #{@options[:in_file]}..."
-    Dir.mkdir("#{@options[:out_dir]}/projects") unless Dir.exist?("#{@options[:out_dir]}/projects")
-    Dir.mkdir("#{@options[:out_dir]}/projects/#{@options[:vol]}") unless Dir.exist?("#{@options[:out_dir]}/projects/#{@options[:vol]}")
-
-    terms = {}
-    file = open(@options[:in_file])
-
-    file.each do |line|
-      term = line.match(/^[^\d]*/)[0].strip
-      terms[term] = line.gsub(/[^0-9, ]/, '').split(/,| /).reject(&:empty?)
-    end
-
-    pages_hash = {}
-    terms.each do |term, pages|
-
-      pages.each do |page|
-        if page.to_i.even?
-          _next = (page.to_i + 1).to_s
-          _pages = "#{page.rjust(3, '0')}-#{_next.rjust(3, '0')}"
-        else
-          _prev = (page.to_i - 1).to_s
-          _pages = "#{_prev.rjust(3, '0')}-#{page.rjust(3, '0')}"
-        end
-
-        pages_hash[_pages] ||= []
-        pages_hash[_pages] << term unless pages_hash[_pages].include?(term) or term.nil?
-      end
-
-    end
-
-    p "Done!"
-    outfile = "#{@options[:out_dir]}/projects/#{@options[:vol]}/terms_by_page.json"
-    File.open(outfile,"w"){|f| f.write(pages_hash.to_json)}
-    p "wrote #{pages_hash.length} items to #{outfile}"
-  end
-
-  def self.write_terms_to_md
-    # ex: ruby scrape_indesign.rb --infile /Users/edwardsharp/Desktop/index8/out/projects/2018/pages.json --out /Users/edwardsharp/Desktop/index8/out/projects/2018/ --writeterms
-    p "reading #{@options[:in_file]}..."
-    j = JSON.parse( File.read(@options[:in_file]) )
-    len = j.length
-    idx = 0
-    j.each do |item|
-      status_update(len:len, idx:idx)
-      project_file = "#{@options[:out_dir]}/#{item[0]}.md"
-      unless File.exist?(project_file)
-        p "WARN: #{project_file} doesnot exist!"
-        next
-      end
-      project = read_md(file:project_file)
-      project[:yml]["tags"] = item[1].sort_by(&:downcase).uniq
-      File.open(project_file,"w"){|f| f.write("#{project[:yml].to_yaml}---#{project[:description]}")}
-    end
-  end
 
   def self.build_terms_index
      # ex: ruby scrape_indesign.rb --infile /Users/edwardsharp/src/github/emergencyindex/emergencyindex.com/utilz/projects/2017/terms.json --termsindex
@@ -467,7 +410,7 @@ module ScrapeIndesign
       project[:yml]["title"].upcase!
       project[:yml]["contributor"].upcase!
 
-      File.open(file,"w"){|f| f.write("#{project[:yml].to_yaml}---\n\n#{project[:description]}")} unless @options[:drytidy]
+      File.open(file,"w"){|f| f.write("#{project[:yml].to_yaml}---\n#{project[:description]}")} unless @options[:drytidy]
       idx += 1
     end
 
@@ -522,7 +465,7 @@ module ScrapeIndesign
       if hasimg and needToReWrite
         p "re-writing image #{project[:yml]["image"]} to #{img} for #{file}."
         project[:yml]["image"] = img
-        File.open(file,"w"){|f| f.write("#{project[:yml].to_yaml}---\n\n#{project[:description]}")}
+        File.open(file,"w"){|f| f.write("#{project[:yml].to_yaml}---\n#{project[:description]}")}
       end
 
       unless hasimg
@@ -571,23 +514,16 @@ private
     {yml: yml, description: description}
   end
 
-  # misc shit
-  def dump_from_rails
-    project_template = File.read Rails.root.join('app/views/projects/jekyll.html.erb')
-    Project.where(volume: Volume.where(year: 2011)).each do |project|
-      @project = project
-      outfile = "/Users/edward/src/tower/github/alveol.us/utilz/projects/2011/#{project.pages}.md"
-      File.open(outfile,"w") do |f|
-        f.write(ERB.new(project_template).result(binding))
-        p "wrote #{outfile}"
-      end
+  def self.page_to_pages(page_string = '')
+    page = page_string.strip
+    if page.to_i.even?
+      _next = (page.to_i + 1).to_s
+      return "#{page.rjust(3, '0')}-#{_next.rjust(3, '0')}"
+    else
+      _prev = (page.to_i - 1).to_s
+      return "#{_prev.rjust(3, '0')}-#{page.rjust(3, '0')}"
     end
-  end
 
-  def rename_imgz(dir: "/Users/edward/src/tower/github/alveol.us/assets/img/2011/")
-    Dir["#{dir}*.jpg"].each do |img|
-      File.rename(File.basename(img), File.basename(img).gsub(/[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/,'_'))
-    end
   end
 
 end


### PR DESCRIPTION
some improvements to the tags scrape'r

the main thing here is writing individual tags when there's a base tag instead of concatenating the base term onto the term tag. so for example tags like: `communication 25, 53, 111, 127, 185, 207, 209, 225, 229, 265, 359, 377, 433, 463, 465, 561; tele-communication 431` previously would write project 431 with a tag `communication tele-communication` but now would write two tags: `communication` and `tele-communication`.

other examples which involve a lot of repetition and maybe are not really sensical: `love lover`, `religion Catholicism`, `voice voice over`. see changes to the 2018 projects tags doing it this way over here: https://github.com/emergencyindex/projects-2018/commit/99f5e67ddbe084f2d8b96e2c0728249fa06e5074

this PR also improves (or refactors, mostly) the terms scrape'r. the idea is use a dry-run (which will still output files) but otherwise write the terms in one command (i.e. not needing to first write to .json file then read that file again to write project .md files). 

still #TODO:

- [x] create the terms index .md file (previous years involved a lot of manual editing of this thing :feelsgood:) see: https://github.com/emergencyindex/projects-2018/commit/2f401dc0f55538c8755754fcb5b9dc22c13e6f92